### PR TITLE
Client: Populate name and url fields with their current values when editing a source

### DIFF
--- a/client/src/components/Source.svelte
+++ b/client/src/components/Source.svelte
@@ -24,6 +24,7 @@
 
     export let id;
     export let name = "[no name]";
+    export let url = "[no url]";
     export let noedit = false;
     export let editSource;
     export let delSource;
@@ -60,6 +61,8 @@
                     editing = false;
                 }}
                 handleCancel={() => editing = false}
+                name={name}
+                url={url}
             />
         {/if}
         {#if deleting}

--- a/client/src/forms/EditSource.svelte
+++ b/client/src/forms/EditSource.svelte
@@ -38,8 +38,8 @@
 <script>
     export let handleSubmit;
     export let handleCancel;
-    let name;
-    let url;
+    export let name = "";
+    export let url = "";
 </script>
 
 <form 


### PR DESCRIPTION
In order to not have to hunt down the URL (or curl the arss server for it, more likely) when I just want to change the name of the feed, this fix allows you to optionally feed in the default values for `name` and `url` to an `EditSource`, and then supplies in the current values when editing an existing source.